### PR TITLE
Add PSM model and dataset feature utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ We use [Wandb](https://wandb.ai/site) for the visualization of learning curves.
 If you want to disable it, please set `use_wandb` to `False` in the folder [`config/`](config/).
 Also, other configurations can be modified in the folder [`config/`](config/).
 
+### 5. PSM training
+
+To train the PSM model you must first pre-compute sentence features using `SentenceTransformer`:
+
+```bash
+python script/gen_text_features.py \
+    --data data/activitynet/train_data.json \
+    --output data/activitynet/train_sentence_features.npy
+```
+
+After generating features (do the same for Charades if needed), run training with the PSM configuration:
+
+```bash
+python train.py --config-path config/activitynet/config_psm.json
+```
+
 ## Acknowledgement
 The following repositories were helpful for our implementation.
 

--- a/config/activitynet/config_psm.json
+++ b/config/activitynet/config_psm.json
@@ -1,0 +1,47 @@
+{
+  "exp_name": "exp-activitynet-psm",
+  "dataset": {
+    "name": "ActivityNet",
+    "feature_path": "data/activitynet/sub_activitynet_v1-3.c3d.hdf5",
+    "train_data": "data/activitynet/train_data.json",
+    "test_data": "data/activitynet/test_data.json",
+    "vocab_path": "data/activitynet/glove.pkl",
+    "vocab_size": 8000,
+    "max_num_words": 20,
+    "max_num_segments": 200,
+    "sim_feat_path": "data/activitynet/train_sentence_features.npy"
+  },
+  "train": {
+    "wandb_path": "./",
+    "log_path": "./log",
+    "save_path": "./checkpoints/activitynet/",
+    "batch_size": 32,
+    "num_epochs": 30,
+    "use_wandb": true,
+    "save_model": true,
+    "optimizer": {
+      "lr": 4e-4,
+      "weight_decay": 0,
+      "warmup_updates": 400,
+      "warmup_init_lr": 1e-7
+    }
+  },
+  "model": {
+    "name": "PSM",
+    "frame_feat_dim": 500,
+    "word_feat_dim": 300,
+    "hidden_dim": 256,
+    "dropout": 0.1,
+    "DualTransformer": {
+      "d_model": 256,
+      "num_heads": 4,
+      "num_decoder_layers1": 2,
+      "num_decoder_layers2": 2,
+      "dropout": 0.1
+    }
+  },
+  "loss": {
+    "psm_margin": 0.2,
+    "psm_tau": 0.07
+  }
+}

--- a/config/charades/config_psm.json
+++ b/config/charades/config_psm.json
@@ -1,0 +1,47 @@
+{
+  "exp_name": "exp-charades-psm",
+  "dataset": {
+    "name": "CharadesSTA",
+    "feature_path": "data/charades/i3d_features.hdf5",
+    "train_data": "data/charades/train.json",
+    "test_data": "data/charades/test.json",
+    "vocab_path": "data/charades/glove.pkl",
+    "vocab_size": 1111,
+    "max_num_words": 20,
+    "max_num_segments": 200,
+    "sim_feat_path": "data/charades/train_sentence_features.npy"
+  },
+  "train": {
+    "wandb_path": "./",
+    "log_path": "./log",
+    "save_path": "./checkpoints/charades/",
+    "batch_size": 32,
+    "num_epochs": 30,
+    "use_wandb": true,
+    "save_model": true,
+    "optimizer": {
+      "lr": 4e-4,
+      "weight_decay": 0,
+      "warmup_updates": 400,
+      "warmup_init_lr": 1e-7
+    }
+  },
+  "model": {
+    "name": "PSM",
+    "frame_feat_dim": 1024,
+    "word_feat_dim": 300,
+    "hidden_dim": 256,
+    "dropout": 0.1,
+    "DualTransformer": {
+      "d_model": 256,
+      "num_heads": 4,
+      "num_decoder_layers1": 2,
+      "num_decoder_layers2": 2,
+      "dropout": 0.1
+    }
+  },
+  "loss": {
+    "psm_margin": 0.2,
+    "psm_tau": 0.07
+  }
+}

--- a/dataset/base.py
+++ b/dataset/base.py
@@ -19,6 +19,12 @@ class BaseDataset(Dataset):
         for w, _ in vocab['counter'].most_common(args['vocab_size']):
             self.keep_vocab[w] = self.vocab_size
 
+        self.sim_feats = None
+        if 'sim_feat_path' in args and args['sim_feat_path']:
+            self.sim_feats = np.load(args['sim_feat_path'])
+            norm = np.linalg.norm(self.sim_feats, axis=1, keepdims=True) + 1e-8
+            self.sim_feats = self.sim_feats / norm
+
     def _load_frame_features(self, vid):
         raise NotImplementedError
 
@@ -70,13 +76,14 @@ class BaseDataset(Dataset):
         words_feat = [self.vocab['id2vec'][self.vocab['w2id'][words[0]]].astype(np.float32)] # placeholder for the start token
         words_feat.extend([self.vocab['id2vec'][self.vocab['w2id'][w]].astype(np.float32) for w in words])
         frames_feat = self._sample_frame_features(self._load_frame_features(vid))
-        
+
         return {
             'frames_feat': frames_feat,
             'words_feat': words_feat,
             'words_id': words_id,
             'weights': weights,
-            'raw': [vid, duration, timestamps, sentence]
+            'raw': [vid, duration, timestamps, sentence],
+            'index': index
         }
 
     def get_samples(self, num_samples):
@@ -91,12 +98,31 @@ class BaseDataset(Dataset):
         return samples
         #return self.collate_fn(samples)
 
+    def get_similar_indices(self, index, top_k=5, positive=True):
+        if self.sim_feats is None:
+            raise ValueError('similarity features not loaded')
+        feat = self.sim_feats[index]
+        sims = np.dot(self.sim_feats, feat)
+        order = sims.argsort()
+        if positive:
+            order = order[::-1]
+            order = order[1:top_k+1]
+        else:
+            order = order[:top_k]
+        return order
+
+    def sample_similar(self, index, top_k=5, positive=True):
+        idxs = self.get_similar_indices(index, top_k=top_k, positive=positive)
+        choice = np.random.choice(idxs)
+        return self.__getitem__(int(choice))
+
 
 def build_collate_data(max_num_segments, max_num_words, frame_dim, word_dim):
     def collate_data(samples):
         bsz = len(samples)
         batch = {
             'raw': [sample['raw'] for sample in samples],
+            'index': [sample['index'] for sample in samples]
         }
 
         frames_len = []

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,1 +1,2 @@
 from .pps import PPS
+from .psm import PSM

--- a/model/psm.py
+++ b/model/psm.py
@@ -1,0 +1,52 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from model.module import SinusoidalPositionalEmbedding, DualTransformer
+
+class PSM(nn.Module):
+    """Simple query-proposal encoder producing global representations."""
+    def __init__(self, config):
+        super().__init__()
+        self.dropout = config['dropout']
+        self.hidden_dim = config['hidden_dim']
+        self.frame_fc = nn.Linear(config['frame_feat_dim'], self.hidden_dim)
+        self.word_fc = nn.Linear(config['word_feat_dim'], self.hidden_dim)
+        self.pred_vec_v = nn.Parameter(torch.zeros(config['frame_feat_dim']).float(), requires_grad=True)
+        self.word_pos_encoder = SinusoidalPositionalEmbedding(self.hidden_dim, 0, config['max_num_words']+1)
+        self.query_encoder = DualTransformer(**config['DualTransformer'])
+        self.prop_encoder = DualTransformer(**config['DualTransformer'])
+
+    def forward(self, frames_feat, frames_len, words_feat, words_len, **kwargs):
+        bsz, n_frames, _ = frames_feat.shape
+
+        pred_vec_v = self.pred_vec_v.view(1, 1, -1).expand(bsz, 1, -1)
+        frames_feat = torch.cat([frames_feat, pred_vec_v], dim=1)
+        frames_feat = F.dropout(frames_feat, self.dropout, self.training)
+        frames_feat = self.frame_fc(frames_feat)
+        frames_mask = _generate_mask(frames_feat, frames_len + 1)
+
+        words_feat = F.dropout(words_feat, self.dropout, self.training)
+        words_feat = self.word_fc(words_feat)
+        words_pos = self.word_pos_encoder(words_feat)
+        words_feat = words_feat + words_pos
+        words_mask = _generate_mask(words_feat, words_len)
+
+        _, q_out = self.query_encoder(frames_feat, frames_mask, words_feat, words_mask, decoding=2)
+        query_repr = q_out.mean(dim=1)
+
+        _, p_out = self.prop_encoder(words_feat, words_mask, frames_feat, frames_mask, decoding=1)
+        prop_repr = p_out.mean(dim=1)
+
+        return {
+            'query_repr': query_repr,
+            'prop_repr': prop_repr
+        }
+
+def _generate_mask(x, x_len):
+    mask = []
+    for l in x_len:
+        mask.append(torch.zeros([x.size(1)]).byte().cuda())
+        mask[-1][:l] = 1
+    mask = torch.stack(mask, 0)
+    return mask

--- a/script/gen_text_features.py
+++ b/script/gen_text_features.py
@@ -1,0 +1,25 @@
+import argparse
+import json
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data', required=True, help='path to training json file')
+    parser.add_argument('--output', required=True, help='output feature npy file')
+    parser.add_argument('--model', default='all-MiniLM-L6-v2', help='sentence transformer model')
+    args = parser.parse_args()
+
+    with open(args.data, 'r', encoding='utf-8') as fr:
+        data = json.load(fr)
+    sentences = [item[3] for item in data]
+
+    st_model = SentenceTransformer(args.model)
+    feats = st_model.encode(sentences, batch_size=64, show_progress_bar=True)
+    np.save(args.output, feats)
+    print('Saved features to', args.output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement new PSM model for global query/proposal representation
- add preprocessing script using SentenceTransformer
- extend dataset class with similarity sampling functions
- support PSM training in runner
- provide PSM configs
- document feature generation and PSM training steps

## Testing
- `python -m py_compile model/psm.py model/loss.py dataset/base.py runner/base_runner.py script/gen_text_features.py`

------
https://chatgpt.com/codex/tasks/task_e_686fa7806a948333ab454d77e494cb1a